### PR TITLE
Fixing issue while git checkout deepspeech: This repository is over its data quota

### DIFF
--- a/Dockerfile.train.tmpl
+++ b/Dockerfile.train.tmpl
@@ -27,11 +27,12 @@ RUN apt-get purge -y python3-xdg
 RUN apt-get install -y --no-install-recommends libopus0 libsndfile1
 
 WORKDIR /
-RUN git lfs install
-RUN git clone $DEEPSPEECH_REPO
+RUN wget https://github.com/mozilla/DeepSpeech/archive/${DEEPSPEECH_SHA}.zip && \
+    unzip ${DEEPSPEECH_SHA}.zip && \
+    mv DeepSpeech-${DEEPSPEECH_SHA} DeepSpeech && \
+    rm -rf ${DEEPSPEECH_SHA}.zip
 
 WORKDIR /DeepSpeech
-RUN git checkout $DEEPSPEECH_SHA
 
 ## Build CTC decoder first, to avoid clashes on incompatible versions upgrades
 #RUN cd native_client/ctcdecode && make NUM_PROCESSES=$(nproc) bindings


### PR DESCRIPTION
The actual error: Error downloading object: data/lm/kenlm.scorer (d0cf926): Smudge error: Error downloading data/lm/kenlm.scorer (d0cf926ab9cab54a8a7d70003b931b2d62ebd9105ed392d1ec9c840029867799): batch response: This repository is over its data quota. Account responsible for LFS bandwidth should purchase more data packs to restore access.

The fix is to use github's HTTP API to get the repo contents as zip

It was also reported here: <https://gitlab.com/Jaco-Assistant/deepspeech-polyglot/-/issues/8>